### PR TITLE
Fix (occasional) message lost on reverse tunnel client

### DIFF
--- a/lib/client_reverse.js
+++ b/lib/client_reverse.js
@@ -101,9 +101,9 @@ wst_client_reverse.prototype.start = function(portTunnel, wsHostUrl, remoteAddr)
 function tcpConnection(wsConn, host, port){
 
   var tcpConn = net.connect( {port: port, host: host}, function(){});
+  bindSockets(wsConn, tcpConn);
 
   tcpConn.on("connect",function(){
-    bindSockets(wsConn, tcpConn);
     //Resume of the WS Socket after the connection to WS Server
     wsConn.socket.resume();
   });


### PR DESCRIPTION
Reverse tunnel client lost websocket message occasionally.
This change fixes the problem by configuring websocket message handler without waiting tcp socket creation.